### PR TITLE
added library_name as mandatory field

### DIFF
--- a/get_submission_xmls/get_ENA_xml_files.py
+++ b/get_submission_xmls/get_ENA_xml_files.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 script_loc = os.path.dirname(sys.argv[0])
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(script_loc + "/templates/"))
-
+print(script_loc)
 def get_attributes (root, parent, child, attr, **element):
     child = root.createElement(attr)
     if element:
@@ -170,12 +170,12 @@ def get_study_xml(project, center, alias, study_name, study_title, description, 
         attributes = get_attributes (root["study"],projects, attributes, 'PROJECT_ATTRIBUTES')
         study_attr = get_attributes (root["study"], attributes, study_attr, 'PROJECT_ATTRIBUTE', **keyword)
 
-def get_experiments (center, alias, species, read_type, instrument, study_alias, sample_ref, flowcell, library_strategy, library_selection, add_lib, add_exp):
+def get_experiments (center, alias, species, read_type, instrument, study_alias, sample_ref, flowcell, library_strategy, library_selection, add_lib, add_exp, library_id):
     exp_title = species + " " + read_type + " " + library_strategy +  " data"
-    lib_name = flowcell + " " + read_type + " " + library_strategy
+    lib_name = flowcell + " " + read_type + " " + library_strategy + " " + library_id
     if read_type == library_strategy:
         exp_title = species + " " + library_strategy +  " data"
-        lib_name = flowcell + " " + library_strategy     
+        lib_name = flowcell + " " + library_strategy + " " + library_id    
 
     source = "GENOMIC"
     if library_strategy == "RNA-Seq":
@@ -427,12 +427,20 @@ if __name__ == "__main__":
           if "annotation" in alternate.lower():
               alternate_annot = "yes"
 
+        library_id = in_file["library_name"][i]
+        add_lib = {}
+        library_attributes = ""
+        if "lib_attr" in in_file and not pd.isna(in_file["lib_attr"][i]) and not in_file["lib_attr"][i] == "-":
+            library_attributes = in_file["lib_attr"][i] 
+            add_lib = library_attributes.replace('{','').replace('}','')
+
+
         if read_type == library_strategy:
-            rname = tolid_pref + "_" + read_type + "_" + sample_id
-            experiments[rname] = "exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id
+            rname = tolid_pref + "_" + read_type + "_" + sample_id + "_" + library_id
+            experiments[rname] = "exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id  + "_" + library_id
         else:
-            rname = tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id
-            experiments[rname] = "exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id
+            rname = tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id + "_" + library_id
+            experiments[rname] = "exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id + "_" + library_id
        
 
         forward_file_name = ""
@@ -480,12 +488,7 @@ if __name__ == "__main__":
                 files_run[native_run] = []
             files_run[native_run].append(native_file_name)       
 
-        add_lib = {}
-        library_attributes = ""
-        if "lib_attr" in in_file and not pd.isna(in_file["lib_attr"][i]) and not in_file["lib_attr"][i] == "-":
-            library_attributes = in_file["lib_attr"][i] 
-            add_lib = library_attributes.replace('{','').replace('}','')
-
+        
         add_exp = {}
         experiment_attributes = ""
         if "exp_attr" in in_file and not pd.isna(in_file["exp_attr"][i]) and not in_file["exp_attr"][i] == "-":
@@ -510,10 +513,10 @@ if __name__ == "__main__":
                     )
 
         if 'all' in args.xml or "experiment" in args.xml:
-            if "exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id not in experiment_register and "exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id not in experiment_register:
-                experiment_register["exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id] = ""
+            if "exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id not in experiment_register and "exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id + "_" + library_id not in experiment_register:
+                experiment_register["exp_" + tolid_pref + "_" + read_type + "_" + library_strategy + "_" + sample_id + "_" + library_id] = ""
                 if read_type == library_strategy:
-                    experiment_register["exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id] = ""
+                    experiment_register["exp_" + tolid_pref + "_" + library_strategy + "_" + sample_id + "_" + library_id] = ""
                
                 get_experiments(
                     center,
@@ -528,11 +531,13 @@ if __name__ == "__main__":
                     library_selection,
                     add_lib,
                     add_exp,
+                    library_id
                 )
 
     if 'all' in args.xml or "runs" in args.xml:
         for run in files_run:
-            run_name = '_'.join(run.split('_')[:-1])
+            run_name = '_'.join(run.split('_')[:-1]) #
+            #print(run_name)
             r = 1
             for file in files_run[run]:
                 get_runs_xml(center, run + "_" + str(r), experiments[run_name], file, files_reverse)


### PR DESCRIPTION
In response to Yvonne's issue with Hi-C libraries. It makes sense to create new experiments for each sequencing library made. This was not being handled correctly. I've introduced a "library_name" field in the input tsv file. It is mandatory for now. Future edits to the script will make it optional.